### PR TITLE
fixing some bugs that makes you lose time for the EnoughDOOMforanArchfiend

### DIFF
--- a/Nation/AFDL/NulgathDemandsWork.cs
+++ b/Nation/AFDL/NulgathDemandsWork.cs
@@ -55,21 +55,22 @@ public class NulgathDemandsWork
 
             Nation.FarmDarkCrystalShard(45);
 
-            Nation.FarmVoucher(false);
-
-            Nation.FarmGemofNulgath(15);
-
-            Nation.SwindleBulk(50);
-
             if (!Core.CheckInventory("Unidentified 27"))
             {
-                Nation.Supplies("Unidentified 26");
+                Nation.Supplies("Unidentified 26", 1, true);
                 Core.EnsureAccept(584);
                 Core.HuntMonster("evilmarsh", "Dark Makai", "Dark Makai Sigil", 1);
                 Core.EnsureComplete(584);
                 Bot.Player.Pickup("Unidentified 27");
                 Core.Logger("Uni 27 acquired");
             }
+
+            Nation.FarmVoucher(false);
+
+            Nation.FarmGemofNulgath(15);
+
+            Nation.SwindleBulk(50);
+
 
             GHV.GetGHV();
 

--- a/Nation/AFDL/WillpowerExtraction.cs
+++ b/Nation/AFDL/WillpowerExtraction.cs
@@ -66,6 +66,13 @@ public class WillpowerExtraction
             Adv.BuyItem("tercessuinotlim", 1951, "Chaoroot", 5, 10);
             Adv.BuyItem("tercessuinotlim", 1951, "Doomatter", 5, 10);
 
+            if (!Core.CheckInventory("Mortality Cape of Revontheus"))
+            {
+                Nation.ApprovalAndFavor(0, 35);
+                Adv.BuyItem("evilwarnul", 452, "Mortality Cape of Revontheus");
+                Bot.Wait.ForItemBuy();
+            }
+
             Core.EquipClass(ClassType.Solo);
             Core.HuntMonster("evilwarnul", "Laken", "King Klunk's Crown", 1, false);
 
@@ -75,12 +82,6 @@ public class WillpowerExtraction
 
             Nation.EssenceofNulgath(10);
 
-            if (!Core.CheckInventory("Mortality Cape of Revontheus"))
-            {
-                Nation.ApprovalAndFavor(0, 35);
-                Adv.BuyItem("evilwarnul", 452, "Mortality Cape of Revontheus");
-                Bot.Wait.ForItemBuy();
-            }
 
             if (!Core.CheckInventory("Facebreakers of Nulgath"))
             {

--- a/Nation/CoreNation.cs
+++ b/Nation/CoreNation.cs
@@ -502,7 +502,7 @@ public class CoreNation
     /// </summary>
     /// <param name=item>Desired item name</param>
     /// <param name="quant">Desired item quantity</param>
-    public void Supplies(string item = "Any", int quant = 1)
+    public void Supplies(string item = "Any", int quant = 1, bool voucherNeeded = false)
     {
         if (Core.CheckInventory(item, quant))
             return;
@@ -547,7 +547,7 @@ public class CoreNation
                 Core.EnsureComplete(2857);
 
                 Bot.Player.Pickup(item);
-                if (item != "Voucher of Nulgath" && sellMemVoucher && Core.CheckInventory("Voucher of Nulgath"))
+                if (item != "Voucher of Nulgath" && sellMemVoucher && Core.CheckInventory("Voucher of Nulgath") && voucherNeeded)
                 {
                     Bot.Player.Pickup("Voucher of Nulgath");
                     Core.SellItem("Voucher of Nulgath", all: true);

--- a/Nation/CoreNation.cs
+++ b/Nation/CoreNation.cs
@@ -547,7 +547,7 @@ public class CoreNation
                 Core.EnsureComplete(2857);
 
                 Bot.Player.Pickup(item);
-                if (item != "Voucher of Nulgath" && sellMemVoucher && Core.CheckInventory("Voucher of Nulgath") && voucherNeeded)
+                if (item != "Voucher of Nulgath" && sellMemVoucher && Core.CheckInventory("Voucher of Nulgath") && !voucherNeeded)
                 {
                     Bot.Player.Pickup("Voucher of Nulgath");
                     Core.SellItem("Voucher of Nulgath", all: true);

--- a/Nation/Various/GoldenHanzoVoid.cs
+++ b/Nation/Various/GoldenHanzoVoid.cs
@@ -29,6 +29,7 @@ public class GoldenHanzoVoid
         Nation.SwindleBulk(30);
         Nation.TheAssistant("Dark Crystal Shard", 15);
         Nation.FarmDiamondofNulgath(50);
+        Nation.FarmVoucher(false);
 
         Core.BuyItem("evilwarnul", 456, "Golden Hanzo Void");
         Bot.Wait.ForItemBuy();


### PR DESCRIPTION
Nation/AFDL/NulgathDemandsWork.cs - when you did the part of getting the mem voucher and then did the part of getting the uni26, for you are doing the quest suplies it would automatically sell the voucher after you got it. Because of that i also put a boolean to confirm that it is safe to sell the voucher 

Nation/AFDL/WillpowerExtraction.cs - it's better for him to buy first and then get the boss items, because for some strange reason Rbot manages to ignore the maximum inventory limit when he drops it from an enemy (I don't have much space in my inventory so I had to do this for the bot work)

Nation/Various/GoldenHanzoVoid.cs - voucher non-mem is needed for buy the goldenhanzovoid

Nation/CoreNation.cs- changes explained in Nation/AFDL/NulgathDemandsWork.cs

my english is not very good so any questions is just ask