### PR TITLE
fixing registerQuest Bug

### DIFF
--- a/CoreBots.cs
+++ b/CoreBots.cs
@@ -134,7 +134,6 @@ public class CoreBots
         Bot.Options.RestPackets = changeTo;
         Bot.Options.AutoRelogin = changeTo;
         Bot.Options.InfiniteRange = changeTo;
-        Bot.Options.ExitCombatBeforeQuest = changeTo;
         Bot.Options.SkipCutscenes = changeTo;
         Bot.Drops.RejectElse = changeTo;
         Bot.Lite.UntargetDead = changeTo;


### PR DESCRIPTION
 When RegisterQuest is going to complete a quest it jumps in the same room so that the enemies stop attacking you, but if huntMoster sends you to another room at the same time as registerQuest do this jump. registerQuest has a chance to overwrite this jump that huntMonster made, causing huntMonster not to attack enemies because it is in a different room than the one that sent you

i think this little change will fix that