### PR TITLE
Added SDKA method for non-member but has SDKA

### DIFF
--- a/Evil/NecroticSwordOfDoom.cs
+++ b/Evil/NecroticSwordOfDoom.cs
@@ -86,18 +86,16 @@ public class NecroticSwordOfDoom
             return;
 
         // Daily.NSoDDaily()
-        if (Core.IsMember)
-        {
-            SDKA.DoAll();
-            CommandingShadowEssences(Quantity);
-        }
-        else if (Core.CheckInventory("Sepulchure's DoomKnight Armor"))
-            CommandingShadowEssences(Quantity);
-        else RetrieveVoidAuras(Quantity);
+           SDKA.DoAll();
+           CommandingShadowEssences(Quantity);
+           RetrieveVoidAuras(Quantity);
     }
 
     public void CommandingShadowEssences(int Quantity)
     {
+        if (!Core.CheckInventory(14474))
+            return;
+        
         if (Core.CheckInventory("Void Aura", Quantity))
             return;
 

--- a/Evil/NecroticSwordOfDoom.cs
+++ b/Evil/NecroticSwordOfDoom.cs
@@ -91,6 +91,8 @@ public class NecroticSwordOfDoom
             SDKA.DoAll();
             CommandingShadowEssences(Quantity);
         }
+        else if (Core.CheckInventory("Sepulchure's DoomKnight Armor"))
+            CommandingShadowEssences(Quantity);
         else RetrieveVoidAuras(Quantity);
     }
 


### PR DESCRIPTION
It would use non-sdka method even if you owned the armour but wasn't member. Quest is no longer Legend Only so...yeah