### PR TITLE
Exalted Apotheosis PreReqs boat

### DIFF
--- a/ExaltedApotheosisPreReqs.cs
+++ b/ExaltedApotheosisPreReqs.cs
@@ -2,7 +2,7 @@
     //cs_include Scripts/CoreFarms.cs
     using Skua.Core.Interfaces;
 
-    public class DefaultTemplate
+    public class ExaltedApotheosisPreReqs
     {
         public IScriptInterface Bot => IScriptInterface.Instance;
         public CoreBots Core => CoreBots.Instance;
@@ -12,12 +12,12 @@
         {
             Core.SetOptions();
 
-            ExaltedApotheosisPreReqs();
+            PreReqs();
 
             Core.SetOptions(false);
         }
 
-        public void ExaltedApotheosisPreReqs()
+        public void PreReqs()
         {
             Core.AddDrop("Exalted Node", "Thaumaturgus Alpha", "Apostate Alpha", "Exalted Relic Piece", "Exalted Forgemetal", "Exalted Artillery Shard");
             if (Core.CheckInventory("Exalted Node", 300) && Core.CheckInventory("Thaumaturgus Alpha") && Core.CheckInventory("Apostate Alpha"))
@@ -54,8 +54,6 @@
                     Core.KillMonster("timeinn", "r3", "Top", "Energy Elemental", log: true);
                 }
                 Core.Logger("Got all prerequisites! Kill the ultra bosses manually for insignias next to complete Exalted Apotheosis.");
-            
-            
             return; 
         }
     }

--- a/ExaltedApotheosisPreReqs.cs
+++ b/ExaltedApotheosisPreReqs.cs
@@ -1,5 +1,6 @@
     //cs_include Scripts/CoreBots.cs
     //cs_include Scripts/CoreFarms.cs
+    //cs_include Scripts/CoreAdvanced.cs
     using Skua.Core.Interfaces;
 
     public class ExaltedApotheosisPreReqs
@@ -7,7 +8,7 @@
         public IScriptInterface Bot => IScriptInterface.Instance;
         public CoreBots Core => CoreBots.Instance;
         public CoreFarms Farm = new();
-
+        public CoreAdvanced Adv = new();
         public void ScriptMain(IScriptInterface bot)
         {
             Core.SetOptions();
@@ -44,6 +45,8 @@
             /// Apotheosis merge once got insignias
             if (Core.CheckInventory("Ezrajal Insignia", 24) && Core.CheckInventory("Warden Insignia", 24) && Core.CheckInventory("Engineer Insignia", 16))
             {
+                /* 
+                ///Keeping these buys in case Adv.BuyItem can't actually merge all the weapons by itself
                 Core.BuyItem("timeinn", 2010, "Apostate Omega");
                 Core.BuyItem("timeinn", 2010, "Apostate Ultima");
                 Core.BuyItem("timeinn", 2010, "Thaumaturgus Omega");
@@ -51,6 +54,8 @@
                 Core.BuyItem("timeinn", 2010, "Exalted Unity");
                 Core.BuyItem("timeinn", 2010, "Exalted Penultima");
                 Core.BuyItem("timeinn", 2010, "Exalted Apotheosis");
+                 */
+                Adv.BuyItem("timeinn", 2010, "Exalted Apotheosis");
                 Core.Logger("Congratulations on completing the Exalted Apotheosis weapon!");
             }
 

--- a/ExaltedApotheosisPreReqs.cs
+++ b/ExaltedApotheosisPreReqs.cs
@@ -19,41 +19,45 @@
 
         public void PreReqs()
         {
-            Core.AddDrop("Exalted Node", "Thaumaturgus Alpha", "Apostate Alpha", "Exalted Relic Piece", "Exalted Forgemetal", "Exalted Artillery Shard");
             if (Core.CheckInventory("Exalted Node", 300) && Core.CheckInventory("Thaumaturgus Alpha") && Core.CheckInventory("Apostate Alpha"))
                 Core.Logger("Got all prerequisites! Kill the ultra bosses manually for insignias next to complete Exalted Apotheosis.");
                 return;
 
+            /// No ultras required
             if (!Core.CheckInventory("Apostate Alpha") && !Core.CheckInventory("Thaumaturgus Alpha"))
-                Core.EquipClass(ClassType.Solo);
-                while (!Bot.ShouldExit && !Core.CheckInventory("Exalted Node", 300))
                 {
-                    Core.KillMonster("timeinn", "r3", "Top", "Energy Elemental", log: true);
-                }
+                    Core.EquipClass(ClassType.Solo);
                 
-                while (!Bot.ShouldExit && !Core.CheckInventory("Exalted Relic Piece", 10))
-                {
-                    Core.KillMonster("timeinn", "r7", "Bottom", "The Warden", log: true);
-                }
+                    Core.KillMonster("timeinn", "r3", "Top", "Energy Elemental", "Exalted Node", 300, isTemp: false);
+                    Core.KillMonster("timeinn", "r7", "Bottom", "The Warden", "Exalted Relic Piece", 10, isTemp: false);
+                    Core.KillMonster("timeinn", "r8", "Left", "The Engineer", "Exalted Artillery Shard", 10, isTemp: false);
+                    Core.KillMonster("timeinn", "r6", "Left", "Ezrajal", "Exalted Forgemetal", 10, isTemp: false);
                 
-                while (!Bot.ShouldExit && !Core.CheckInventory("Exalted Artillery Shard", 10))
-                {
-                    Core.KillMonster("timeinn", "r8", "Left", "The Engineer", log: true);
-                }
+                    Core.BuyItem("timeinn", 2010, "Apostate Alpha");
+                    Core.BuyItem("timeinn", 2010, "Thaumaturgus Alpha");
                 
-                while (!Bot.ShouldExit && !Core.CheckInventory("Exalted Forgemetal", 10))
-                {
-                    Core.KillMonster("timeinn", "r6", "Left", "Ezrajal", log: true);
-                }
-                
-                Core.BuyItem("timeinn", 2010, "Apostate Alpha");
-                Core.BuyItem("timeinn", 2010, "Thaumaturgus Alpha");
-                
-                while(!Bot.ShouldExit && !Core.CheckInventory("Exalted Node", 300))
-                {
-                    Core.KillMonster("timeinn", "r3", "Top", "Energy Elemental", log: true);
-                }
-                Core.Logger("Got all prerequisites! Kill the ultra bosses manually for insignias next to complete Exalted Apotheosis.");
-            return; 
+                    Core.KillMonster("timeinn", "r3", "Top", "Energy Elemental", "Exalted Node", 300, isTemp: false);
+                    
+                    Core.Logger("Got all prerequisites! Kill the ultra bosses manually for insignias next to complete Exalted Apotheosis.");
+                } 
+
+            /// Apotheosis merge once got insignias
+            if (Core.CheckInventory("Ezrajal Insignia", 24) && Core.CheckInventory("Warden Insignia", 24) && Core.CheckInventory("Engineer Insignia", 16))
+            {
+                Core.BuyItem("timeinn", 2010, "Apostate Omega");
+                Core.BuyItem("timeinn", 2010, "Apostate Ultima");
+                Core.BuyItem("timeinn", 2010, "Thaumaturgus Omega");
+                Core.BuyItem("timeinn", 2010, "Thaumaturgus Ultima");
+                Core.BuyItem("timeinn", 2010, "Exalted Unity");
+                Core.BuyItem("timeinn", 2010, "Exalted Penultima");
+                Core.BuyItem("timeinn", 2010, "Exalted Apotheosis");
+                Core.Logger("Congratulations on completing the Exalted Apotheosis weapon!");
+            }
+
+            else            
+            {
+                Core.Logger("Please obtain a total of 24 Ezrajal and Warden Insignias and 16 Engineer Insignias with your army to complete the merge. Currently our boats can't do the Ultra Bosses for you until CoreArmy is finished.");
+                return;
+            }
         }
     }

--- a/ExaltedApotheosisPreReqs.cs
+++ b/ExaltedApotheosisPreReqs.cs
@@ -1,0 +1,61 @@
+    //cs_include Scripts/CoreBots.cs
+    //cs_include Scripts/CoreFarms.cs
+    using Skua.Core.Interfaces;
+
+    public class DefaultTemplate
+    {
+        public IScriptInterface Bot => IScriptInterface.Instance;
+        public CoreBots Core => CoreBots.Instance;
+        public CoreFarms Farm = new();
+
+        public void ScriptMain(IScriptInterface bot)
+        {
+            Core.SetOptions();
+
+            ExaltedApotheosisPreReqs();
+
+            Core.SetOptions(false);
+        }
+
+        public void ExaltedApotheosisPreReqs()
+        {
+            Core.AddDrop("Exalted Node", "Thaumaturgus Alpha", "Apostate Alpha", "Exalted Relic Piece", "Exalted Forgemetal", "Exalted Artillery Shard");
+            if (Core.CheckInventory("Exalted Node", 300) && Core.CheckInventory("Thaumaturgus Alpha") && Core.CheckInventory("Apostate Alpha"))
+                Core.Logger("Got all prerequisites! Kill the ultra bosses manually for insignias next to complete Exalted Apotheosis.");
+                return;
+
+            if (!Core.CheckInventory("Apostate Alpha") && !Core.CheckInventory("Thaumaturgus Alpha"))
+                Core.EquipClass(ClassType.Solo);
+                while (!Bot.ShouldExit && !Core.CheckInventory("Exalted Node", 300))
+                {
+                    Core.KillMonster("timeinn", "r3", "Top", "Energy Elemental", log: true);
+                }
+                
+                while (!Bot.ShouldExit && !Core.CheckInventory("Exalted Relic Piece", 10))
+                {
+                    Core.KillMonster("timeinn", "r7", "Bottom", "The Warden", log: true);
+                }
+                
+                while (!Bot.ShouldExit && !Core.CheckInventory("Exalted Artillery Shard", 10))
+                {
+                    Core.KillMonster("timeinn", "r8", "Left", "The Engineer", log: true);
+                }
+                
+                while (!Bot.ShouldExit && !Core.CheckInventory("Exalted Forgemetal", 10))
+                {
+                    Core.KillMonster("timeinn", "r6", "Left", "Ezrajal", log: true);
+                }
+                
+                Core.BuyItem("timeinn", 2010, "Apostate Alpha");
+                Core.BuyItem("timeinn", 2010, "Thaumaturgus Alpha");
+                
+                while(!Bot.ShouldExit && !Core.CheckInventory("Exalted Node", 300))
+                {
+                    Core.KillMonster("timeinn", "r3", "Top", "Energy Elemental", log: true);
+                }
+                Core.Logger("Got all prerequisites! Kill the ultra bosses manually for insignias next to complete Exalted Apotheosis.");
+            
+            
+            return; 
+        }
+    }


### PR DESCRIPTION
Farms the components of Exalted Apotheosis that don't require any ultra boss insignias. Not sure if the class name can/has to be changed cuz first boat so lmk, forgot to delete extra white spaces at the return at the end :dedw: